### PR TITLE
openvswitch: depends on libunbound

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -9,9 +9,14 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
+# Checklist on version bump
+#
+#  - Check acinclude.m4 for range of supported kernel versions: "but version newer than .* is not supported"
+#  - Check and update kmod dependencies when necessary (runtime module load check in the least)
+#
 PKG_NAME:=openvswitch
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=64f7cdcfffc73b2e09980d04ee22731eadd6453698b92d7397c9e45c7c174050
@@ -32,67 +37,101 @@ include ../../lang/python/python-host.mk
 include ../../lang/python/python-package.mk
 
 
-CONFIGURE_ARGS+= \
-	--enable-ndebug \
-	--enable-shared \
-	--disable-libcapng \
+ovs_kmod_packages:=
+ovs_kmod_intree_kernel_patchver_min:=3.10
+ovs_kmod_intree_kernel_patchver_max:=4.15
+ovs_kmod_intree_not_supported:=$(strip $(call kernel_patchver_lt,$(ovs_kmod_intree_kernel_patchver_min))$(call kernel_patchver_gt,$(ovs_kmod_intree_kernel_patchver_max)))
+ovs_kmod_intree_dir:=$(PKG_BUILD_DIR)/datapath/linux
+ovs_kmod_upstream_dir:=$(LINUX_DIR)/net/openvswitch
+ovs_kmod_package_name=$(if $(filter openvswitch,$(1)),openvswitch,$(1))
+ovs_kmod_is_intree=$(filter %-intree,$(1))
+ovs_kmod_upstream_name=kmod-$(call ovs_kmod_package_name,$(patsubst %-intree,%,$(1)))
+ovs_kmod_package_provides=$(call ovs_kmod_upstream_name,$(1))
+define OvsKmodPackageTemplate
+  define KernelPackage/$(call ovs_kmod_package_name,$(1))
+     SECTION:=kernel
+     CATEGORY:=Kernel modules
+     SUBMENU:=Network Support
+     TITLE:=$(ovs_kmod_$(1)_title)
+     DEPENDS:=$(ovs_kmod_$(1)_depends) $(if $(call ovs_kmod_is_intree,$(1)),@DEVEL $(if $(ovs_kmod_intree_not_supported),@BROKEN))
+     PROVIDES:=$(call ovs_kmod_package_provides,$(1))
+     KCONFIG:=$(ovs_kmod_$(1)_kconfig)
+     FILES:=$(ovs_kmod_$(1)_files)
+     AUTOLOAD:=$(call AutoProbe,$(foreach m,$(ovs_kmod_$(1)_files),$(patsubst %.ko,%,$(basename $(m)))))
+  endef
 
-CONFIGURE_VARS += \
-	ovs_cv_flake8=no \
-	ovs_cv_python3=no \
-	ovs_cv_sphinx=no \
-	ovs_cv_python=$(PYTHON) \
-	ovs_cv_python_host=$(HOST_PYTHON_BIN) \
-
-TARGET_CFLAGS += -flto -std=gnu99
-MAKE_VARS += PYTHONPATH="$(HOST_PYTHONPATH)"
-
-
-define KernelPackage/openvswitch
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Open vSwitch kernel datapath
-  KCONFIG:=CONFIG_OPENVSWITCH
-  DEPENDS:= \
-	+kmod-lib-crc32c +kmod-mpls \
-	+kmod-nf-nat +IPV6:kmod-nf-nat6
-  FILES:= $(LINUX_DIR)/net/openvswitch/openvswitch.ko
-  AUTOLOAD:=$(call AutoProbe,openvswitch)
+  ovs_kmod_packages+=$(call ovs_kmod_package_name,$(1))
 endef
 
-define KernelPackage/openvswitch-gre
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Open vSwitch GRE tunneling support
-  KCONFIG:= CONFIG_OPENVSWITCH_GRE
-  DEPENDS:= +kmod-openvswitch +kmod-gre
-  FILES:= $(LINUX_DIR)/net/openvswitch/vport-gre.ko
-  AUTOLOAD:=$(call AutoProbe,vport-gre)
-endef
+ovs_kmod_openvswitch_title:=Open vSwitch kernel datapath (upstream)
+ovs_kmod_openvswitch_kconfig:=CONFIG_OPENVSWITCH
+ovs_kmod_openvswitch_depends:=\
+	  +kmod-lib-crc32c +kmod-mpls \
+	  +kmod-nf-nat +IPV6:kmod-nf-nat6 \
+	  +kmod-nf-conntrack +IPV6:kmod-nf-conntrack6
+ovs_kmod_openvswitch_files:=$(ovs_kmod_upstream_dir)/openvswitch.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch))
 
-define KernelPackage/openvswitch-vxlan
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Open vSwitch VXLAN tunneling support
-  KCONFIG:= CONFIG_OPENVSWITCH_VXLAN
-  DEPENDS:= +kmod-openvswitch +kmod-vxlan
-  FILES:= $(LINUX_DIR)/net/openvswitch/vport-vxlan.ko
-  AUTOLOAD:=$(call AutoProbe,vport-vxlan)
-endef
+ovs_kmod_openvswitch-gre_title:=Open vSwitch GRE tunneling support (upstream)
+ovs_kmod_openvswitch-gre_kconfig:= CONFIG_OPENVSWITCH_GRE
+ovs_kmod_openvswitch-gre_depends:= +kmod-openvswitch +kmod-gre
+ovs_kmod_openvswitch-gre_files:= $(ovs_kmod_upstream_dir)/vport-gre.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-gre))
 
-define KernelPackage/openvswitch-geneve
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Open vSwitch Geneve tunneling support
-  KCONFIG:= CONFIG_OPENVSWITCH_GENEVE
-  DEPENDS:= +kmod-openvswitch +kmod-geneve
-  FILES:= $(LINUX_DIR)/net/openvswitch/vport-geneve.ko
-  AUTOLOAD:=$(call AutoProbe,vport-geneve)
-endef
+ovs_kmod_openvswitch-vxlan_title:=Open vSwitch VXLAN tunneling support (upstream)
+ovs_kmod_openvswitch-vxlan_kconfig:= CONFIG_OPENVSWITCH_VXLAN
+ovs_kmod_openvswitch-vxlan_depends:= +kmod-openvswitch +kmod-vxlan
+ovs_kmod_openvswitch-vxlan_files:= $(ovs_kmod_upstream_dir)/vport-vxlan.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-vxlan))
+
+ovs_kmod_openvswitch-geneve_title:=Open vSwitch Geneve tunneling support (upstream)
+ovs_kmod_openvswitch-geneve_kconfig:= CONFIG_OPENVSWITCH_GENEVE
+ovs_kmod_openvswitch-geneve_depends:= +kmod-openvswitch +kmod-geneve
+ovs_kmod_openvswitch-geneve_files:= $(ovs_kmod_upstream_dir)/vport-geneve.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-geneve))
+
+# NOTE depends
+#
+#  - kmod-gre: with linux-4.14, ovs-2.10, when ovs decides to not
+#    USE_UPSTREAM_TUNNEL, it requires kmod-gre to be enabled so that
+#    CONFIG_NET_IPGRE_DEMUX is enabled and ovs will have rpl_gre_init()
+#    compiled in.
+#
+#  - kmod-gre6: with linux-4.14, ovs-2.10, when ovs decides to not
+#    USE_UPSTREAM_TUNNEL, it requires xfrm6_tunnel_register() from
+#    net/ipv6/tunnel6.ko, which will be pulled in by kmod-ip6-tunnel, which
+#    will be pulled in by kmod-gre6.  NOTE that tunnel6.ko itself cannot be
+#    enabled and selected on its own
+#
+ovs_kmod_openvswitch-intree_title:=Open vSwitch kernel datapath (in tree)
+ovs_kmod_openvswitch-intree_depends:=$(ovs_kmod_openvswitch_depends) +kmod-gre +IPV6:kmod-gre6
+ovs_kmod_openvswitch-intree_files:= $(ovs_kmod_intree_dir)/openvswitch.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-intree))
+
+ovs_kmod_openvswitch-gre-intree_title:=Open vSwitch GRE tunneling support (in tree)
+ovs_kmod_openvswitch-gre-intree_depends:= +kmod-openvswitch-intree +kmod-gre
+ovs_kmod_openvswitch-gre-intree_files:= $(ovs_kmod_intree_dir)/vport-gre.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-gre-intree))
+
+ovs_kmod_openvswitch-vxlan-intree_title:=Open vSwitch VXLAN tunneling support (in tree)
+ovs_kmod_openvswitch-vxlan-intree_depends:= +kmod-openvswitch-intree +kmod-vxlan
+ovs_kmod_openvswitch-vxlan-intree_files:= $(ovs_kmod_intree_dir)/vport-vxlan.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-vxlan-intree))
+
+ovs_kmod_openvswitch-geneve-intree_title:=Open vSwitch Geneve tunneling support (in tree)
+ovs_kmod_openvswitch-geneve-intree_depends:= +kmod-openvswitch-intree +kmod-geneve
+ovs_kmod_openvswitch-geneve-intree_files:= $(ovs_kmod_intree_dir)/vport-geneve.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-geneve-intree))
+
+ovs_kmod_openvswitch-stt-intree_title:=Open vSwitch STT tunneling support (in tree)
+ovs_kmod_openvswitch-stt-intree_depends:= +kmod-openvswitch-intree
+ovs_kmod_openvswitch-stt-intree_files:= $(ovs_kmod_intree_dir)/vport-stt.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-stt-intree))
+
+ovs_kmod_openvswitch-lisp-intree_title:=Open vSwitch LISP tunneling support (in tree)
+ovs_kmod_openvswitch-lisp-intree_depends:= +kmod-openvswitch-intree
+ovs_kmod_openvswitch-lisp-intree_files:= $(ovs_kmod_intree_dir)/vport-lisp.ko
+$(eval $(call OvsKmodPackageTemplate,openvswitch-lisp-intree))
 
 
 ovs_packages:=
@@ -244,11 +283,32 @@ endef
 $(eval $(call OvsPackageTemplate,python))
 
 
+CONFIGURE_ARGS+= \
+	--enable-ndebug \
+	--enable-shared \
+	--disable-libcapng \
+
+CONFIGURE_VARS += \
+	ovs_cv_flake8=no \
+	ovs_cv_python3=no \
+	ovs_cv_sphinx=no \
+	ovs_cv_python=$(PYTHON) \
+	ovs_cv_python_host=$(HOST_PYTHON_BIN) \
+	KARCH=$(LINUX_KARCH) \
+
+ovs_intree_kmod_configs:=CONFIG_PACKAGE_kmod-openvswitch-intree
+ovs_intree_kmod_enabled:=$(strip $(foreach c,$(ovs_intree_kmod_configs),$(c)))
+PKG_CONFIG_DEPENDS+=$(ovs_intree_kmod_configs)
+ifneq ($(ovs_intree_kmod_enabled),)
+  CONFIGURE_ARGS += --with-linux=$(LINUX_DIR)
+endif
+
+TARGET_CFLAGS += -flto -std=gnu99
+MAKE_VARS += PYTHONPATH="$(HOST_PYTHONPATH)"
+
+$(foreach p,$(ovs_kmod_packages),\
+  $(eval $(call KernelPackage,$(p)))\
+)
 $(foreach p,$(ovs_packages),\
   $(eval $(call BuildPackage,$(p)))\
 )
-
-$(eval $(call KernelPackage,openvswitch))
-$(eval $(call KernelPackage,openvswitch-gre))
-$(eval $(call KernelPackage,openvswitch-vxlan))
-$(eval $(call KernelPackage,openvswitch-geneve))

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=openvswitch
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=64f7cdcfffc73b2e09980d04ee22731eadd6453698b92d7397c9e45c7c174050
@@ -105,7 +105,7 @@ define OvsPackageTemplate
      URL:=https://www.openvswitch.org
      TITLE:=$(ovs_$(1)_title)
      HIDDEN:=$(ovs_$(1)_hidden)
-     DEPENDS:=$(ovs_$(1)_depends)
+     DEPENDS:=$(ovs_$(1)_depends) +libunbound
   endef
 
   define Package/$(call ovs_package_name,$(1))/install

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=openvswitch
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=64f7cdcfffc73b2e09980d04ee22731eadd6453698b92d7397c9e45c7c174050
@@ -173,6 +173,7 @@ ovs_common_depends:=+librt +openvswitch-libopenvswitch +openvswitch-libofproto +
 ovs_common_files:= \
 	usr/share/openvswitch/scripts/ovs-lib \
 	usr/share/openvswitch/scripts/ovs-ctl \
+	usr/share/openvswitch/scripts/ovs-kmod-ctl \
 	usr/share/openvswitch/scripts/ovs-save \
 	$(foreach b,ovs-appctl ovs-dpctl ovs-ofctl ovs-vsctl ovsdb-client ovsdb-tool,usr/bin/$(b))
 define ovs_common_install
@@ -184,6 +185,7 @@ define ovs_common_install
 	$$(INSTALL_DIR) $$(1)/usr/share/openvswitch/scripts
 	$$(INSTALL_BIN) ./files/ovs-ctl-wrapper $$(1)/usr/share/openvswitch/scripts/
 	$$(LN) /usr/share/openvswitch/scripts/ovs-ctl-wrapper $$(1)/usr/bin/ovs-ctl
+	$$(LN) /usr/share/openvswitch/scripts/ovs-ctl-wrapper $$(1)/usr/bin/ovs-kmod-ctl
 endef
 define Package/openvswitch-common/conffiles
 /etc/openvswitch

--- a/net/openvswitch/README.md
+++ b/net/openvswitch/README.md
@@ -27,3 +27,36 @@ mainly a wrapper around `ovs-ctl` and `ovn-ctl` with simple knobs from
 	/etc/init.d/openvswitch status
 
 Use `ovs-ctl` and `ovn-ctl` directly for more functionalities
+
+# Open vSwitch in-tree Linux datapath modules
+
+The Open vSwitch build system uses regexp and conditional-compilation
+heuristics to support building the shipped kernel module source code against a
+wide range of kernels, as of openvswitch-2.10, the list is supposed to include
+vanilla linux 3.10 to 4.15, plus a few distro kernels.
+
+It may NOT work
+
+ - Sometimes the code does not compile
+ - Sometimes the code compiles but insmod will fail
+ - Sometimes modules are loaded okay but actually does not function right
+
+For these reasons, the in-tree datapath modules are NOT visible/enabled by
+default.
+
+Building and using in-tree datapath modules requires some level of devel
+abilities to proceed.  You are expected to configure build options and build
+the code on your own
+
+E.g. pair openvswitch userspace with in-tree datapath module
+
+	CONFIG_DEVEL=y
+	CONFIG_PACKAGE_openvswitch=y
+	# CONFIG_PACKAGE_kmod-openvswitch is not set
+	CONFIG_PACKAGE_kmod-openvswitch-intree=y
+
+E.g. replace in-tree datapath module with upstream version
+
+	opkg remove --force-depends kmod-openvswitch-intree
+	opkg install kmod-openvswitch
+	ovs-ctl force-reload-kmod

--- a/net/openvswitch/files/openvswitch.init
+++ b/net/openvswitch/files/openvswitch.init
@@ -6,8 +6,8 @@
 START=15
 
 ovs_script_dir=/usr/share/openvswitch/scripts
-ovs_ctl="$ovs_script_dir/ovs-ctl"
-ovn_ctl="$ovs_script_dir/ovn-ctl"
+ovs_ctl="$ovs_script_dir/ovs-ctl"; [ -x "$ovs_ctl" ] || ovs_ctl=:
+ovn_ctl="$ovs_script_dir/ovn-ctl"; [ -x "$ovn_ctl" ] || ovn_ctl=:
 
 EXTRA_COMMANDS=status
 

--- a/net/openvswitch/files/ovs-ctl-wrapper
+++ b/net/openvswitch/files/ovs-ctl-wrapper
@@ -3,6 +3,7 @@
 s=/usr/share/openvswitch/scripts
 case "$0" in
 	*ovs-ctl) "$s/ovs-ctl" "$@" ;;
+	*ovs-kmod-ctl) "$s/ovs-kmod-ctl" "$@" ;;
 	*ovn-ctl) "$s/ovn-ctl" "$@" ;;
 	*) exit 1;;
 esac

--- a/net/openvswitch/patches/0100-netdev-linux-Use-unsigned-int-for-ifi_flags.patch
+++ b/net/openvswitch/patches/0100-netdev-linux-Use-unsigned-int-for-ifi_flags.patch
@@ -1,7 +1,7 @@
-From 054968d5748c9ff73a69155cd64f0e81287d3bb3 Mon Sep 17 00:00:00 2001
+From e4ac9741a99866976322c21605b312bc27633c92 Mon Sep 17 00:00:00 2001
 From: Helmut Schaa <helmut.schaa@googlemail.com>
 Date: Wed, 8 Jan 2014 13:48:33 +0100
-Subject: [PATCH 100/105] netdev-linux: Use unsigned int for ifi_flags
+Subject: [PATCH 100/106] netdev-linux: Use unsigned int for ifi_flags
 
 ifi_flags is unsigned, the local equivalents should do the same.
 

--- a/net/openvswitch/patches/0100-netdev-linux-Use-unsigned-int-for-ifi_flags.patch
+++ b/net/openvswitch/patches/0100-netdev-linux-Use-unsigned-int-for-ifi_flags.patch
@@ -1,7 +1,7 @@
 From e4ac9741a99866976322c21605b312bc27633c92 Mon Sep 17 00:00:00 2001
 From: Helmut Schaa <helmut.schaa@googlemail.com>
 Date: Wed, 8 Jan 2014 13:48:33 +0100
-Subject: [PATCH 100/106] netdev-linux: Use unsigned int for ifi_flags
+Subject: [PATCH 100/107] netdev-linux: Use unsigned int for ifi_flags
 
 ifi_flags is unsigned, the local equivalents should do the same.
 

--- a/net/openvswitch/patches/0101-netdev-linux-Let-interface-flag-survive-internal-por.patch
+++ b/net/openvswitch/patches/0101-netdev-linux-Let-interface-flag-survive-internal-por.patch
@@ -1,7 +1,7 @@
-From a3eabe1e639c98ce8537df4ac4187a8c047dac59 Mon Sep 17 00:00:00 2001
+From 9f4775d9a2541e8128ea99f3b02925cc1ee05374 Mon Sep 17 00:00:00 2001
 From: Helmut Schaa <helmut.schaa@googlemail.com>
 Date: Wed, 8 Jan 2014 13:48:49 +0100
-Subject: [PATCH 101/105] netdev-linux: Let interface flag survive internal
+Subject: [PATCH 101/106] netdev-linux: Let interface flag survive internal
  port setup
 
 Due to a race condition when bringing up an internal port on Linux

--- a/net/openvswitch/patches/0101-netdev-linux-Let-interface-flag-survive-internal-por.patch
+++ b/net/openvswitch/patches/0101-netdev-linux-Let-interface-flag-survive-internal-por.patch
@@ -1,7 +1,7 @@
 From 9f4775d9a2541e8128ea99f3b02925cc1ee05374 Mon Sep 17 00:00:00 2001
 From: Helmut Schaa <helmut.schaa@googlemail.com>
 Date: Wed, 8 Jan 2014 13:48:49 +0100
-Subject: [PATCH 101/106] netdev-linux: Let interface flag survive internal
+Subject: [PATCH 101/107] netdev-linux: Let interface flag survive internal
  port setup
 
 Due to a race condition when bringing up an internal port on Linux

--- a/net/openvswitch/patches/0102-python-separate-host-target-python-for-cross-compile.patch
+++ b/net/openvswitch/patches/0102-python-separate-host-target-python-for-cross-compile.patch
@@ -1,7 +1,7 @@
-From b5c6d8c2e1ba0c3d9b93622f68f6c0b9e9c62f0d Mon Sep 17 00:00:00 2001
+From e451d74788c73e8679e6a2268185a08901ac7f8c Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <zhouyousong@yunionyun.com>
 Date: Tue, 21 Aug 2018 12:21:05 +0000
-Subject: [PATCH 102/105] python: separate host/target python for cross-compile
+Subject: [PATCH 102/106] python: separate host/target python for cross-compile
 
 At the moment, python-six is a requirement for openvswitch python
 library on target machine.

--- a/net/openvswitch/patches/0102-python-separate-host-target-python-for-cross-compile.patch
+++ b/net/openvswitch/patches/0102-python-separate-host-target-python-for-cross-compile.patch
@@ -1,7 +1,7 @@
 From e451d74788c73e8679e6a2268185a08901ac7f8c Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <zhouyousong@yunionyun.com>
 Date: Tue, 21 Aug 2018 12:21:05 +0000
-Subject: [PATCH 102/106] python: separate host/target python for cross-compile
+Subject: [PATCH 102/107] python: separate host/target python for cross-compile
 
 At the moment, python-six is a requirement for openvswitch python
 library on target machine.

--- a/net/openvswitch/patches/0103-ovs-ctl-fix-setting-hostname.patch
+++ b/net/openvswitch/patches/0103-ovs-ctl-fix-setting-hostname.patch
@@ -1,7 +1,7 @@
 From 6b9732c8851c5466f2a363d88b5acae320801efe Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Wed, 14 Mar 2018 16:40:01 +0800
-Subject: [PATCH 103/106] ovs-ctl: fix setting hostname
+Subject: [PATCH 103/107] ovs-ctl: fix setting hostname
 
 The command "hostname" is not available in OpenWrt by default.
 

--- a/net/openvswitch/patches/0103-ovs-ctl-fix-setting-hostname.patch
+++ b/net/openvswitch/patches/0103-ovs-ctl-fix-setting-hostname.patch
@@ -1,7 +1,7 @@
-From 0b8ef58a26ed8d426acfe1fa27713cbcc2427f3f Mon Sep 17 00:00:00 2001
+From 6b9732c8851c5466f2a363d88b5acae320801efe Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Wed, 14 Mar 2018 16:40:01 +0800
-Subject: [PATCH 103/105] ovs-ctl: fix setting hostname
+Subject: [PATCH 103/106] ovs-ctl: fix setting hostname
 
 The command "hostname" is not available in OpenWrt by default.
 

--- a/net/openvswitch/patches/0104-ovs-lib-fix-install_dir.patch
+++ b/net/openvswitch/patches/0104-ovs-lib-fix-install_dir.patch
@@ -1,7 +1,7 @@
-From 97107da940da7814c3e9e947aee1c247cd7b95db Mon Sep 17 00:00:00 2001
+From 940441e2982cb35765830060e8203e5dd1a0f967 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Wed, 14 Mar 2018 16:44:13 +0800
-Subject: [PATCH 104/105] ovs-lib: fix install_dir()
+Subject: [PATCH 104/106] ovs-lib: fix install_dir()
 
 The command "install" is not available in OpenWrt by default
 

--- a/net/openvswitch/patches/0104-ovs-lib-fix-install_dir.patch
+++ b/net/openvswitch/patches/0104-ovs-lib-fix-install_dir.patch
@@ -1,7 +1,7 @@
 From 940441e2982cb35765830060e8203e5dd1a0f967 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Wed, 14 Mar 2018 16:44:13 +0800
-Subject: [PATCH 104/106] ovs-lib: fix install_dir()
+Subject: [PATCH 104/107] ovs-lib: fix install_dir()
 
 The command "install" is not available in OpenWrt by default
 

--- a/net/openvswitch/patches/0105-build-disable-building-tests.patch
+++ b/net/openvswitch/patches/0105-build-disable-building-tests.patch
@@ -1,7 +1,7 @@
-From f5c6e5d4c567f3705de503b7271d384d1aad88ab Mon Sep 17 00:00:00 2001
+From d0cad5ac122aca722dc2013c1f53fda44c477cf2 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <zhouyousong@yunionyun.com>
 Date: Tue, 21 Aug 2018 13:02:21 +0000
-Subject: [PATCH 105/105] build: disable building tests
+Subject: [PATCH 105/106] build: disable building tests
 
 Signed-off-by: Yousong Zhou <zhouyousong@yunionyun.com>
 ---

--- a/net/openvswitch/patches/0105-build-disable-building-tests.patch
+++ b/net/openvswitch/patches/0105-build-disable-building-tests.patch
@@ -1,7 +1,7 @@
 From d0cad5ac122aca722dc2013c1f53fda44c477cf2 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <zhouyousong@yunionyun.com>
 Date: Tue, 21 Aug 2018 13:02:21 +0000
-Subject: [PATCH 105/106] build: disable building tests
+Subject: [PATCH 105/107] build: disable building tests
 
 Signed-off-by: Yousong Zhou <zhouyousong@yunionyun.com>
 ---

--- a/net/openvswitch/patches/0106-ovs-save-compatible-with-busybox-ip-command.patch
+++ b/net/openvswitch/patches/0106-ovs-save-compatible-with-busybox-ip-command.patch
@@ -1,0 +1,26 @@
+From 2a59f2b60e8a22dc93d48c511b5c4255b429ff66 Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <zhouyousong@yunionyun.com>
+Date: Wed, 5 Sep 2018 12:32:54 +0000
+Subject: [PATCH 106/106] ovs-save: compatible with busybox ip command
+
+Busybox ip command will have exit code 1 for `ip -V` or `ip help` etc.,
+use `ip rule list` to cover both iproute2 and busybox ip command
+
+Signed-off-by: Yousong Zhou <zhouyousong@yunionyun.com>
+---
+ utilities/ovs-save | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utilities/ovs-save b/utilities/ovs-save
+index ea8fb6a45..72d460df4 100755
+--- a/utilities/ovs-save
++++ b/utilities/ovs-save
+@@ -38,7 +38,7 @@ EOF
+ }
+ 
+ save_interfaces () {
+-    if (ip -V) > /dev/null 2>&1; then :; else
++    if (ip rule list) > /dev/null 2>&1; then :; else
+         echo "$0: ip not found in $PATH" >&2
+         exit 1
+     fi

--- a/net/openvswitch/patches/0106-ovs-save-compatible-with-busybox-ip-command.patch
+++ b/net/openvswitch/patches/0106-ovs-save-compatible-with-busybox-ip-command.patch
@@ -1,7 +1,7 @@
 From 2a59f2b60e8a22dc93d48c511b5c4255b429ff66 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <zhouyousong@yunionyun.com>
 Date: Wed, 5 Sep 2018 12:32:54 +0000
-Subject: [PATCH 106/106] ovs-save: compatible with busybox ip command
+Subject: [PATCH 106/107] ovs-save: compatible with busybox ip command
 
 Busybox ip command will have exit code 1 for `ip -V` or `ip help` etc.,
 use `ip rule list` to cover both iproute2 and busybox ip command

--- a/net/openvswitch/patches/0107-datapath-use-KARCH-when-building-linux-datapath-modu.patch
+++ b/net/openvswitch/patches/0107-datapath-use-KARCH-when-building-linux-datapath-modu.patch
@@ -1,0 +1,28 @@
+From 1e859f407b94a0f549fc41fceec11ca12653878b Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <zhouyousong@yunionyun.com>
+Date: Thu, 6 Sep 2018 11:48:20 +0000
+Subject: [PATCH 107/107] datapath: use KARCH when building linux datapath
+ modules
+
+Signed-off-by: Yousong Zhou <zhouyousong@yunionyun.com>
+---
+ datapath/linux/Makefile.main.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/datapath/linux/Makefile.main.in b/datapath/linux/Makefile.main.in
+index 7d18253be..039485d16 100644
+--- a/datapath/linux/Makefile.main.in
++++ b/datapath/linux/Makefile.main.in
+@@ -68,10 +68,10 @@ ifeq (,$(wildcard $(CONFIG_FILE)))
+ endif
+ 
+ default:
+-	$(MAKE) -C $(KSRC) M=$(builddir) modules
++	$(MAKE) -C $(KSRC) $(if @KARCH@,ARCH=@KARCH@) M=$(builddir) modules
+ 
+ modules_install:
+-	$(MAKE) -C $(KSRC) M=$(builddir) modules_install
++	$(MAKE) -C $(KSRC) $(if @KARCH@,ARCH=@KARCH@) M=$(builddir) modules_install
+ 	depmod `sed -n 's/#define UTS_RELEASE "\([^"]*\)"/\1/p' $(KSRC)/include/generated/utsrelease.h`
+ endif
+ 


### PR DESCRIPTION
This is introduced in Open vSwitch 2.10 in commit 771680d ("DNS: Add
basic support for asynchronous DNS resolving")

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
